### PR TITLE
Use https for pastebin.com and paste2.org

### DIFF
--- a/pastebin.d/paste2.org.conf
+++ b/pastebin.d/paste2.org.conf
@@ -1,6 +1,7 @@
 [pastebin]
 basename = paste2.org
-regexp = http://paste2.org
+regexp = https://paste2.org
+https = True
 
 [format]
 title = description

--- a/pastebin.d/pastebin.com.conf
+++ b/pastebin.d/pastebin.com.conf
@@ -1,6 +1,7 @@
 [pastebin]
 basename = pastebin.com
-regexp = http://((([a-zA-Z0-9\-_\.]*)(pastebin\.com)))
+regexp = https://((([a-zA-Z0-9\-_\.]*)(pastebin\.com)))
+https = True
 
 [format]
 content = api_paste_code


### PR DESCRIPTION
https is required for both of these services now.

Not sure if your accepting PRs.  pastebinit appears to be currently unmaintained/abandoned.